### PR TITLE
TelephonyProvider : Add sub_id to ICC columns

### DIFF
--- a/src/com/android/providers/telephony/SmsProvider.java
+++ b/src/com/android/providers/telephony/SmsProvider.java
@@ -115,7 +115,8 @@ public class SmsProvider extends ContentProvider {
         "locked",                       // Always 0 (false).
         "error_code",                   // Always 0
         "_id",
-        "phone_id"
+        "phone_id",
+        "sub_id"
     };
 
     @Override
@@ -299,7 +300,7 @@ public class SmsProvider extends ContentProvider {
                 type = Sms.MESSAGE_TYPE_OUTBOX;
                 break;
         }
-        Object[] row = new Object[14];
+        Object[] row = new Object[15];
         row[0] = message.getServiceCenterAddress();
         row[1] = (type == Sms.MESSAGE_TYPE_INBOX)
                 ? message.getDisplayOriginatingAddress()
@@ -316,6 +317,7 @@ public class SmsProvider extends ContentProvider {
         row[11] = 0;      // error_code
         row[12] = id;
         row[13] = phoneId;
+        row[14] = message.getSubId();
         return row;
     }
 


### PR DESCRIPTION
sub_id was replaced with phone_id in b2fc4be and c22bb84
Adding sub_id alongside phone_id to revive broken Mms app functionality

Change-Id: I03feb9cb0d2b3fc174dbe9c1dc66d702caf7f651